### PR TITLE
Fixed canvas ctx.restore() implementation (non-mozilla browsers)

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -143,8 +143,8 @@ function addContextCurrentTransform(ctx) {
       var prev = this._transformStack.pop();
       if (prev) {
         this._transformMatrix = prev;
-        this._originalRestore();
       }
+      this._originalRestore();
     };
 
     ctx.translate = function ctxTranslate(x, y) {


### PR DESCRIPTION
The problem is in current ctx.restore() implementation. It does its job well only if there is a transform in stack. It begins to matter when context is reused after PDFJS rendering.
Incorrect behavior can be reproduced in the following scenario:

``` javascript
 // rendering PDF page into a clipped region:
var ctx = canvas.getContext("2d"); // native context implementation
 ctx.save();  // original state is saved in stack
 ctx.rect(0,0,100,100) 
 ctx.clip();  // context is clipped
...
page.render({context: ctx, viewport:...}) 
// at this point, PDFJS overrides original ctx.save and ctx.restore with custom implementations
...
ctx.restore(); // ctx._originalRestore() is NOT called, since there is no transform in stack!
// context must not be clipped at this point
```
